### PR TITLE
Make it work with ruby 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ rvm:
   - 2.1.8
   - 2.2.4
   - 2.3.0
+  - 3.0.2
 matrix:
   include:
     - rvm: jruby

--- a/lib/pincushion/plugins/csv_serializer.rb
+++ b/lib/pincushion/plugins/csv_serializer.rb
@@ -1,10 +1,9 @@
 require 'csv'
 
 module Pincushion
-  def self.from_csv(csv, *args)
-    args << {} unless args.last.is_a?(Hash)
-    args.last.merge!(Plugins::CsvSerializer::OPTS)
-    from_rows(CSV.parse(csv, *args).map(&:to_hash))
+  def self.from_csv(csv, opts = {})
+    opts = opts.merge(Plugins::CsvSerializer::OPTS)
+    from_rows(CSV.parse(csv, **opts).map(&:to_hash))
   end
 
   module Plugins
@@ -22,11 +21,10 @@ module Pincushion
       }.freeze
 
       module RootModuleMethods
-        def to_csv(*args)
-          args << {} unless args.last.is_a?(Hash)
-          args.last[:headers] ||= [:identifier, *predicates]
+        def to_csv(opts)
+          opts[:headers] ||= [:identifier, *predicates]
 
-          CSV.generate(*args) do |csv|
+          CSV.generate(**opts) do |csv|
             rows.each { |row| csv << row }
           end
         end

--- a/lib/pincushion/version.rb
+++ b/lib/pincushion/version.rb
@@ -1,3 +1,3 @@
 module Pincushion
-  VERSION = "0.1.3"
+  VERSION = "0.1.4"
 end # module Pincushion

--- a/pincushion.gemspec
+++ b/pincushion.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>=2.0'
 
-  s.add_development_dependency "bundler", "~> 1.0"
-  s.add_development_dependency "rake", "~> 10.0"
+  s.add_development_dependency "bundler", "~> 2.0"
+  s.add_development_dependency "rake", "~> 13.0"
   s.add_development_dependency "minitest", "~> 5.0"
 end

--- a/pincushion.gemspec
+++ b/pincushion.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.files       = Dir['{spec,lib}/**/*.{rb,yaml}']
   s.test_files  = Dir['spec/**/*.{rb,yaml}']
 
-  s.required_ruby_version = '~>2.0'
+  s.required_ruby_version = '>=2.0'
 
   s.add_development_dependency "bundler", "~> 1.0"
   s.add_development_dependency "rake", "~> 10.0"

--- a/spec/pincushion_spec.rb
+++ b/spec/pincushion_spec.rb
@@ -46,7 +46,7 @@ describe Pincushion do
     animals.predicates :herbivore
 
     elephants = animals.that_are(:herbivore)
-    tiny_elephants = elephants.that_is.named("Tree Trunks")
+    elephants.that_is.named("Tree Trunks")
 
     assert_raises Pincushion::MissingPredicateError do
       animals.that_is(:carnivore)


### PR DESCRIPTION
I bumped Bundler version because I figure most dev environments will have newer Bundler and it removed a load of warnings for me.  If this is bad practice then I'm happy to take that change out.